### PR TITLE
fix: Agregar webdriver.remote.url faltante para BrowserStack

### DIFF
--- a/src/test/resources/serenity.conf
+++ b/src/test/resources/serenity.conf
@@ -72,6 +72,9 @@ environments {
     webdriver.base.url = "https://webx.muthematrix.com/"
     webdriver.driver = remote
 
+    # URL de BrowserStack - se construye dinámicamente con las credenciales
+    webdriver.remote.url = "https://"${BROWSERSTACK_USER}":"${BROWSERSTACK_KEY}"@hub-cloud.browserstack.com/wd/hub"
+
     browserstack.user = ${?BROWSERSTACK_USER}
     browserstack.key = ${?BROWSERSTACK_KEY}
     browserstack.local = false


### PR DESCRIPTION
- Error: 'A webdriver.remote.url property must be defined when using a Remote driver'
- Agregada URL remota con credenciales dinámicas
- Formato: https://USER:KEY@hub-cloud.browserstack.com/wd/hub
- Ahora Serenity podrá conectarse correctamente a BrowserStack